### PR TITLE
PropagatedVersion changes to support namespaces

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -426,6 +426,17 @@ func (s *FederationSyncController) reconcile(qualifiedName federatedtypes.Qualif
 	templateAdapter := s.adapter.Template()
 	kind := templateAdapter.Kind()
 	key := qualifiedName.String()
+	namespace := qualifiedName.Namespace
+
+	if federatedtypes.IsNamespaceKind(kind) {
+		namespace = qualifiedName.Name
+		// TODO(font): Need a configurable or discoverable list of namespaces
+		// to not propagate beyond just the default system namespaces e.g.
+		// clusterregistry.
+		if isSystemNamespace(namespace) {
+			return statusAllOK
+		}
+	}
 
 	glog.V(4).Infof("Starting to reconcile %v %v", kind, key)
 	startTime := time.Now()
@@ -480,7 +491,7 @@ func (s *FederationSyncController) reconcile(qualifiedName federatedtypes.Qualif
 	}
 
 	propagatedVersionKey := federatedtypes.QualifiedName{
-		Namespace: qualifiedName.Namespace,
+		Namespace: namespace,
 		Name:      s.versionName(qualifiedName.Name),
 	}.String()
 	// TODO(marun) LOCK!
@@ -537,7 +548,7 @@ func (s *FederationSyncController) delete(template pkgruntime.Object, meta *meta
 		return err
 	}
 
-	if kind == federatedtypes.NamespaceKind {
+	if federatedtypes.IsNamespaceKind(kind) {
 		// Return immediately if we are a namespace as it will be deleted
 		// simply by removing its finalizers.
 		return nil
@@ -658,9 +669,11 @@ func updatePropagatedVersion(adapter federatedtypes.FederatedTypeAdapter,
 		if err != nil {
 			return err
 		}
+
 		key := federatedtypes.NewQualifiedName(version).String()
 		// TODO(marun) add timeout to ensure against lost updates blocking propagation of a given resource
 		pendingVersionUpdates.Insert(key)
+
 		_, err = adapter.FedClient().FederationV1alpha1().PropagatedVersions(version.Namespace).UpdateStatus(version)
 		if err != nil {
 			pendingVersionUpdates.Delete(key)
@@ -688,6 +701,7 @@ func updatePropagatedVersion(adapter federatedtypes.FederatedTypeAdapter,
 
 	key := federatedtypes.NewQualifiedName(version).String()
 	pendingVersionUpdates.Insert(key)
+
 	_, err := adapter.FedClient().FederationV1alpha1().PropagatedVersions(version.Namespace).UpdateStatus(version)
 	if err != nil {
 		pendingVersionUpdates.Delete(key)
@@ -708,9 +722,16 @@ func newVersion(clusterVersions map[string]string, templateMeta *metav1.ObjectMe
 	}
 
 	util.SortClusterVersions(versions)
+	var namespace string
+	if federatedtypes.IsNamespaceKind(targetKind) {
+		namespace = templateMeta.Name
+	} else {
+		namespace = templateMeta.Namespace
+	}
+
 	return &fedv1a1.PropagatedVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: templateMeta.Namespace,
+			Namespace: namespace,
 			Name:      common.PropagatedVersionName(targetKind, templateMeta.Name),
 		},
 		Status: fedv1a1.PropagatedVersionStatus{
@@ -772,8 +793,25 @@ func (s *FederationSyncController) clusterOperations(selectedClusters, unselecte
 		}
 
 		var operationType util.FederatedOperationType = ""
+
 		if found {
 			clusterObj := clusterObj.(pkgruntime.Object)
+
+			// If we're a namespace kind and this is an object for the primary
+			// cluster, then skip the version comparison check as we do not
+			// track the cluster version for namespaces in the primary cluster.
+			// This avoids unnecessary updates that triggers an infinite loop
+			// of continually adding finalizers and then removing finalizers,
+			// causing PropagatedVersion to not keep up with the
+			// ResourceVersions being updated.
+			if federatedtypes.IsNamespaceKind(kind) {
+				templateMeta := s.adapter.Template().ObjectMeta(template)
+				clusterMeta := s.adapter.Target().ObjectMeta(clusterObj)
+				if util.IsPrimaryCluster(templateMeta, clusterMeta) {
+					continue
+				}
+			}
+
 			desiredObj = s.adapter.ObjectForUpdateOp(desiredObj, clusterObj)
 
 			version, ok := clusterVersions[clusterName]
@@ -843,4 +881,15 @@ func newFedApiInformer(typeAdapter federatedtypes.FedApiAdapter, triggerFunc fun
 		util.NoResyncPeriod,
 		util.NewTriggerOnAllChanges(triggerFunc),
 	)
+}
+
+// TODO (font): Externalize this list to a package var to allow it to be
+// configurable.
+func isSystemNamespace(namespace string) bool {
+	switch namespace {
+	case "kube-system", util.FederationSystemNamespace:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -119,3 +119,11 @@ var KubeconfigGetterForSecret = func(secret *apiv1.Secret) clientcmd.KubeconfigG
 		return clientcmd.Load(data)
 	}
 }
+
+// IsPrimaryCluster checks if the caller is working with objects for the
+// primary cluster by checking if the UIDs match for both ObjectMetas passed
+// in.
+// TODO (font): Need to revisit this when cluster ID is available.
+func IsPrimaryCluster(federatedMeta, clusterMeta *metav1.ObjectMeta) bool {
+	return federatedMeta.UID == clusterMeta.UID
+}

--- a/pkg/controller/util/deletionhelper/deletion_helper.go
+++ b/pkg/controller/util/deletionhelper/deletion_helper.go
@@ -151,8 +151,8 @@ func (dh *DeletionHelper) HandleObjectInUnderlyingClusters(obj runtime.Object,
 		// Skip the update if this object is for the primary cluster as that
 		// namespace will simply be removed after removing its finalizers.
 		if kind == federatedtypes.NamespaceKind {
-			clusterObjUID := clusterNsObj.Object.(*corev1.Namespace).UID
-			if meta.UID == clusterObjUID {
+			clusterObjMeta := &clusterNsObj.Object.(*corev1.Namespace).ObjectMeta
+			if util.IsPrimaryCluster(meta, clusterObjMeta) {
 				continue
 			}
 		}

--- a/pkg/federatedtypes/namespace.go
+++ b/pkg/federatedtypes/namespace.go
@@ -38,6 +38,10 @@ func init() {
 	RegisterTestObjectsFunc(NamespaceKind, NewFederatedNamespaceObjectsForTest)
 }
 
+func IsNamespaceKind(kind string) bool {
+	return kind == NamespaceKind
+}
+
 type FederatedNamespaceAdapter struct {
 	client    kubeclientset.Interface
 	fedClient fedclientset.Interface

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -45,7 +45,7 @@ type FederatedTypeCrudTester struct {
 	adapter          federatedtypes.FederatedTypeAdapter
 	kind             string
 	comparisonHelper util.ComparisonHelper
-	clusterClients   map[string]clientset.Interface
+	testClusters     map[string]TestCluster
 	waitInterval     time.Duration
 	// Federation operations will use wait.ForeverTestTimeout.  Any
 	// operation that involves member clusters may take longer due to
@@ -53,7 +53,12 @@ type FederatedTypeCrudTester struct {
 	clusterWaitTimeout time.Duration
 }
 
-func NewFederatedTypeCrudTester(testLogger TestLogger, adapter federatedtypes.FederatedTypeAdapter, clusterClients map[string]clientset.Interface, waitInterval, clusterWaitTimeout time.Duration) (*FederatedTypeCrudTester, error) {
+type TestCluster struct {
+	Client    clientset.Interface
+	IsPrimary bool
+}
+
+func NewFederatedTypeCrudTester(testLogger TestLogger, adapter federatedtypes.FederatedTypeAdapter, testClusters map[string]TestCluster, waitInterval, clusterWaitTimeout time.Duration) (*FederatedTypeCrudTester, error) {
 	compare, err := util.NewComparisonHelper(adapter.Target().VersionCompareType())
 	if err != nil {
 		return nil, err
@@ -64,7 +69,7 @@ func NewFederatedTypeCrudTester(testLogger TestLogger, adapter federatedtypes.Fe
 		adapter:            adapter,
 		kind:               adapter.Template().Kind(),
 		comparisonHelper:   compare,
-		clusterClients:     clusterClients,
+		testClusters:       testClusters,
 		waitInterval:       waitInterval,
 		clusterWaitTimeout: clusterWaitTimeout,
 	}, nil
@@ -158,7 +163,6 @@ func (c *FederatedTypeCrudTester) CheckUpdate(template, placement, override pkgr
 	qualifiedName := federatedtypes.NewQualifiedName(template)
 
 	adapter := c.adapter.Template()
-	kind := adapter.Kind()
 
 	var initialAnnotation string
 	meta := adapter.ObjectMeta(template)
@@ -166,7 +170,7 @@ func (c *FederatedTypeCrudTester) CheckUpdate(template, placement, override pkgr
 		initialAnnotation = meta.Annotations[AnnotationTestFederationCrudUpdate]
 	}
 
-	c.tl.Logf("Updating %s %q", kind, qualifiedName)
+	c.tl.Logf("Updating %s %q", c.kind, qualifiedName)
 	updatedTemplate, err := c.updateFedObject(adapter, template, func(template pkgruntime.Object) {
 		// Target the metadata for simplicity (it's type-agnostic)
 		meta := adapter.ObjectMeta(template)
@@ -176,14 +180,14 @@ func (c *FederatedTypeCrudTester) CheckUpdate(template, placement, override pkgr
 		meta.Annotations[AnnotationTestFederationCrudUpdate] = "updated"
 	})
 	if err != nil {
-		c.tl.Fatalf("Error updating %s %q: %v", kind, qualifiedName, err)
+		c.tl.Fatalf("Error updating %s %q: %v", c.kind, qualifiedName, err)
 	}
 
 	// updateFedObject is expected to have changed the value of the annotation
 	meta = adapter.ObjectMeta(updatedTemplate)
 	updatedAnnotation := meta.Annotations[AnnotationTestFederationCrudUpdate]
 	if updatedAnnotation == initialAnnotation {
-		c.tl.Fatalf("%s %q not mutated", kind, qualifiedName)
+		c.tl.Fatalf("%s %q not mutated", c.kind, qualifiedName)
 	}
 
 	c.CheckPropagation(updatedTemplate, placement, override)
@@ -200,12 +204,12 @@ func (c *FederatedTypeCrudTester) CheckPlacementChange(template, placement, over
 
 	clusterNames := adapter.ClusterNames(placement)
 
-	// TODO (font): Also check to see if this single cluster is the host
-	// cluster as that's really the only time we want to skip when there's only
-	// 1 cluster. Skipping avoids deleting the namespace from the entire
+	// Skip if we're a namespace, we only have one cluster, and it's the
+	// primary cluster. Skipping avoids deleting the namespace from the entire
 	// federation by removing this single cluster from the placement, because
 	// if deleted, this fails the next CheckDelete test.
-	if kind == federatedtypes.FederatedNamespacePlacementKind && len(clusterNames) == 1 {
+	if kind == federatedtypes.FederatedNamespacePlacementKind && len(clusterNames) == 1 &&
+		clusterNames[0] == c.getPrimaryClusterName() {
 		c.tl.Logf("Skipping %s placement update for %q due to single primary cluster",
 			kind, qualifiedName)
 		return
@@ -214,13 +218,7 @@ func (c *FederatedTypeCrudTester) CheckPlacementChange(template, placement, over
 	c.tl.Logf("Updating %s %q", kind, qualifiedName)
 	updatedPlacement, err := c.updateFedObject(adapter, placement, func(placement pkgruntime.Object) {
 		clusterNames := adapter.ClusterNames(placement)
-		// Remove a cluster name
-		// TODO (font): Make sure to not remove the host cluster when testing
-		// namespaces. We assume the host cluster is first in the list so
-		// instead we always keep it and remove the last value. If we remove
-		// the host cluster when testing namespaces, it will delete the
-		// namespace from the entire federation.
-		clusterNames = clusterNames[:len(clusterNames)-1]
+		clusterNames = c.deleteOneNonPrimaryCluster(clusterNames)
 		adapter.SetClusterNames(placement, clusterNames)
 	})
 	if err != nil {
@@ -271,7 +269,11 @@ func (c *FederatedTypeCrudTester) CheckDelete(obj pkgruntime.Object, orphanDepen
 
 	// Version tracker should also be removed
 	versionName := c.versionName(qualifiedName.Name)
-	_, err = c.adapter.FedClient().FederationV1alpha1().PropagatedVersions(qualifiedName.Namespace).Get(versionName, metav1.GetOptions{})
+	if federatedtypes.IsNamespaceKind(c.kind) {
+		_, err = c.adapter.FedClient().FederationV1alpha1().PropagatedVersions(qualifiedName.Name).Get(versionName, metav1.GetOptions{})
+	} else {
+		_, err = c.adapter.FedClient().FederationV1alpha1().PropagatedVersions(qualifiedName.Namespace).Get(versionName, metav1.GetOptions{})
+	}
 	if !errors.IsNotFound(err) {
 		c.tl.Fatalf("Expecting PropagatedVersion %s to be deleted", versionName)
 	}
@@ -281,8 +283,8 @@ func (c *FederatedTypeCrudTester) CheckDelete(obj pkgruntime.Object, orphanDepen
 		stateMsg = "not present"
 	}
 	targetAdapter := c.adapter.Target()
-	for _, client := range c.clusterClients {
-		_, err := targetAdapter.Get(client, qualifiedName)
+	for _, testCluster := range c.testClusters {
+		_, err := targetAdapter.Get(testCluster.Client, qualifiedName)
 		switch {
 		case !deletingInCluster && errors.IsNotFound(err):
 			c.tl.Fatalf("%s %q was unexpectedly deleted from a member cluster", c.kind, qualifiedName)
@@ -301,13 +303,21 @@ func (c *FederatedTypeCrudTester) CheckPropagation(template, placement, override
 	clusterNames := c.adapter.Placement().ClusterNames(placement)
 	selectedClusters := sets.NewString(clusterNames...)
 
+	// If we are a namespace, there is only one cluster, and the cluster is the
+	// host cluster, then do not check for PropagatedVersion as it will never
+	// be created.
+	if federatedtypes.IsNamespaceKind(c.kind) && len(clusterNames) == 1 &&
+		clusterNames[0] == c.getPrimaryClusterName() {
+		return
+	}
+
 	version, err := c.waitForPropagatedVersion(template, placement, override)
 	if err != nil {
 		c.tl.Fatalf("Error waiting for propagated version for %s %q: %v", c.kind, qualifiedName, err)
 	}
 
 	// TODO(marun) run checks in parallel
-	for clusterName, client := range c.clusterClients {
+	for clusterName, testCluster := range c.testClusters {
 		objExpected := selectedClusters.Has(clusterName)
 
 		operation := "to be deleted from"
@@ -316,12 +326,12 @@ func (c *FederatedTypeCrudTester) CheckPropagation(template, placement, override
 		}
 		c.tl.Logf("Waiting for %s %q %s cluster %q", c.kind, qualifiedName, operation, clusterName)
 
-		expectedVersion := propagatedVersion(version, clusterName)
+		expectedVersion := c.propagatedVersion(version, clusterName)
 		if objExpected {
 			if expectedVersion == "" {
 				c.tl.Fatalf("Failed to determine expected resource version of %s %q in cluster %q.", c.kind, qualifiedName, clusterName)
 			}
-			err := c.waitForResource(client, qualifiedName, expectedVersion)
+			err := c.waitForResource(testCluster.Client, qualifiedName, expectedVersion)
 			switch {
 			case err == wait.ErrWaitTimeout:
 				c.tl.Fatalf("Timeout verifying %s %q in cluster %q: %v", c.kind, qualifiedName, clusterName, err)
@@ -332,7 +342,7 @@ func (c *FederatedTypeCrudTester) CheckPropagation(template, placement, override
 			if expectedVersion != "" {
 				c.tl.Fatalf("Expected resource version for %s %q in cluster %q to be removed", c.kind, qualifiedName, clusterName)
 			}
-			err := c.waitForResourceDeletion(client, qualifiedName)
+			err := c.waitForResourceDeletion(testCluster.Client, qualifiedName)
 			// Once resource deletion is complete, wait for the status to reflect the deletion
 
 			switch {
@@ -343,7 +353,6 @@ func (c *FederatedTypeCrudTester) CheckPropagation(template, placement, override
 			case err != nil:
 				c.tl.Fatalf("Failed to verify deletion of %s %q in cluster %q: %v", c.kind, qualifiedName, clusterName, err)
 			}
-
 		}
 	}
 }
@@ -400,10 +409,11 @@ func (c *FederatedTypeCrudTester) updateFedObject(adapter federatedtypes.FedApiA
 func (c *FederatedTypeCrudTester) waitForPropagatedVersion(template, placement, override pkgruntime.Object) (*fedv1a1.PropagatedVersion, error) {
 	templateMeta := c.adapter.Template().ObjectMeta(template)
 	templateQualifiedName := federatedtypes.NewQualifiedName(template)
+
 	overrideVersion := ""
-	if c.adapter.Override() != nil {
-		overrideMeta := c.adapter.Override().ObjectMeta(override)
-		overrideVersion = overrideMeta.ResourceVersion
+	overrideAdapter := c.adapter.Override()
+	if overrideAdapter != nil {
+		overrideVersion = overrideAdapter.ObjectMeta(override).ResourceVersion
 	}
 
 	client := c.adapter.FedClient()
@@ -412,11 +422,20 @@ func (c *FederatedTypeCrudTester) waitForPropagatedVersion(template, placement, 
 
 	clusterNames := c.adapter.Placement().ClusterNames(placement)
 	selectedClusters := sets.NewString(clusterNames...)
+	if federatedtypes.IsNamespaceKind(c.kind) {
+		// Delete the primary cluster as it will never be included in
+		// PropagatedVersion's list of cluster versions.
+		selectedClusters.Delete(c.getPrimaryClusterName())
+	}
 
 	var version *fedv1a1.PropagatedVersion
 	err := wait.PollImmediate(c.waitInterval, c.clusterWaitTimeout, func() (bool, error) {
 		var err error
-		version, err = client.FederationV1alpha1().PropagatedVersions(namespace).Get(name, metav1.GetOptions{})
+		if federatedtypes.IsNamespaceKind(c.kind) {
+			version, err = client.FederationV1alpha1().PropagatedVersions(templateMeta.Name).Get(name, metav1.GetOptions{})
+		} else {
+			version, err = client.FederationV1alpha1().PropagatedVersions(namespace).Get(name, metav1.GetOptions{})
+		}
 		if errors.IsNotFound(err) {
 			return false, nil
 		}
@@ -451,7 +470,38 @@ func (c *FederatedTypeCrudTester) versionName(resourceName string) string {
 	return common.PropagatedVersionName(targetKind, resourceName)
 }
 
-func propagatedVersion(version *fedv1a1.PropagatedVersion, clusterName string) string {
+func (c *FederatedTypeCrudTester) getPrimaryClusterName() string {
+	for name, testCluster := range c.testClusters {
+		if testCluster.IsPrimary {
+			return name
+		}
+	}
+	return ""
+}
+
+func (c *FederatedTypeCrudTester) deleteOneNonPrimaryCluster(clusterNames []string) []string {
+	primaryClusterName := c.getPrimaryClusterName()
+
+	for i, name := range clusterNames {
+		if name == primaryClusterName {
+			continue
+		} else {
+			clusterNames = append(clusterNames[:i], clusterNames[i+1:]...)
+			break
+		}
+	}
+
+	return clusterNames
+}
+
+func (c *FederatedTypeCrudTester) propagatedVersion(version *fedv1a1.PropagatedVersion, clusterName string) string {
+	// For namespaces, since we do not store the primary cluster's namespace
+	// version in PropagatedVersion's ClusterVersions slice, grab it from the
+	// TemplateVersion field instead.
+	if federatedtypes.IsNamespaceKind(c.kind) && clusterName == c.getPrimaryClusterName() {
+		return version.Status.TemplateVersion
+	}
+
 	for _, clusterVersion := range version.Status.ClusterVersions {
 		if clusterVersion.ClusterName == clusterName {
 			return clusterVersion.Version

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -56,15 +56,15 @@ var _ = Describe("Federated types", func() {
 				if ok {
 					namespaceAdapter.SetKubeClient(f.KubeClient(userAgent))
 				}
-				clusterClients := f.ClusterClients(userAgent)
+				testClusters := f.ClusterClients(userAgent)
 				testLogger := framework.NewE2ELogger()
-				crudTester, err := common.NewFederatedTypeCrudTester(testLogger, adapter, clusterClients, framework.PollInterval, framework.SingleCallTimeout)
+				crudTester, err := common.NewFederatedTypeCrudTester(testLogger, adapter, testClusters, framework.PollInterval, framework.SingleCallTimeout)
 				if err != nil {
 					testLogger.Fatalf("Error creating crudtester for %q: %v", kind, err)
 				}
 
 				clusterNames := []string{}
-				for name, _ := range clusterClients {
+				for name, _ := range testClusters {
 					clusterNames = append(clusterNames, name)
 				}
 				template, placement, override := federatedtypes.NewTestObjects(fedTypeConfig.Kind, f.TestNamespaceName(), clusterNames)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -19,6 +19,7 @@ package framework
 import (
 	fedclientset "github.com/marun/federation-v2/pkg/client/clientset_generated/clientset"
 	"github.com/marun/federation-v2/pkg/federatedtypes"
+	"github.com/marun/federation-v2/test/common"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	crclientset "k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
 
@@ -35,7 +36,7 @@ type FederationFramework interface {
 	KubeClient(userAgent string) kubeclientset.Interface
 	CrClient(userAgent string) crclientset.Interface
 
-	ClusterClients(userAgent string) map[string]kubeclientset.Interface
+	ClusterClients(userAgent string) map[string]common.TestCluster
 
 	// Name of the namespace for the current test to target
 	TestNamespaceName() string
@@ -94,7 +95,7 @@ func (f *frameworkWrapper) CrClient(userAgent string) crclientset.Interface {
 	return f.framework().CrClient(userAgent)
 }
 
-func (f *frameworkWrapper) ClusterClients(userAgent string) map[string]kubeclientset.Interface {
+func (f *frameworkWrapper) ClusterClients(userAgent string) map[string]common.TestCluster {
 	return f.framework().ClusterClients(userAgent)
 }
 

--- a/test/e2e/framework/managed.go
+++ b/test/e2e/framework/managed.go
@@ -93,7 +93,7 @@ func (f *ManagedFramework) CrClient(userAgent string) crclientset.Interface {
 	return fedFixture.CrApi.NewClient(f.logger, userAgent)
 }
 
-func (f *ManagedFramework) ClusterClients(userAgent string) map[string]kubeclientset.Interface {
+func (f *ManagedFramework) ClusterClients(userAgent string) map[string]common.TestCluster {
 	return fedFixture.ClusterClients(f.logger, userAgent)
 }
 

--- a/test/integration/framework/kubeapi.go
+++ b/test/integration/framework/kubeapi.go
@@ -36,6 +36,7 @@ type KubernetesApiFixture struct {
 	Host                string
 	SecureConfigFixture *SecureConfigFixture
 	ApiServer           *integration.APIServer
+	IsPrimary           bool
 }
 
 func SetUpKubernetesApiFixture(tl common.TestLogger) *KubernetesApiFixture {


### PR DESCRIPTION
- Changes to support`PropagatedVersion` for namespaces.
- Adds crudtester check for primary cluster so that we can run E2E tests with or without the host cluster being part of the federation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marun/federation-v2/49)
<!-- Reviewable:end -->
