### PR TITLE
Add hybrid mode to E2E testing

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -52,8 +52,14 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		framework.SetUpManagedFederation()
 		// TODO(marun) support parallel execution by sending
 		// configuration for test-managed federation to other nodes
+	} else if framework.TestContext.InMemoryControllers {
+		// This supports a hybrid setup where the user asks for an unmanaged
+		// federation with in memory controllers. This means the k8s clusters
+		// are already running along with the federation cluster registry API
+		// servers. This will then join the clusters and launch the required
+		// federation controllers e.g. cluster and sync controllers.
+		framework.SetUpUnManagedFederation()
 	}
-	// TODO(marun) support deployed federation
 
 	return nil
 
@@ -73,5 +79,7 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 	framework.Logf("Running AfterSuite actions on node 1")
 	if framework.TestContext.TestManagedFederation {
 		framework.TearDownManagedFederation()
+	} else if framework.TestContext.InMemoryControllers {
+		framework.TearDownUnManagedFederation()
 	}
 })

--- a/test/e2e/framework/managed.go
+++ b/test/e2e/framework/managed.go
@@ -29,7 +29,6 @@ import (
 
 var (
 	fedFixture *framework.FederationFixture
-	logger     common.TestLogger
 )
 
 func SetUpManagedFederation() {
@@ -106,6 +105,6 @@ func (f *ManagedFramework) SetUpControllerFixture(kind string, adapterFactory fe
 	fedConfig := fedFixture.FedApi.NewConfig(f.logger)
 	kubeConfig := fedFixture.KubeApi.NewConfig(f.logger)
 	crConfig := fedFixture.CrApi.NewConfig(f.logger)
-	fixture := framework.NewControllerFixture(f.logger, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
+	fixture := framework.NewSyncControllerFixture(f.logger, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
 	f.fixtures = append(f.fixtures, fixture)
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -33,10 +33,14 @@ type TestContextType struct {
 var TestContext TestContextType
 
 func registerFlags(t *TestContextType) {
-	flag.BoolVar(&t.TestManagedFederation, "test-managed-federation", false, "Whether the test run should rely on a test-managed federation.")
-	flag.BoolVar(&t.InMemoryControllers, "in-memory-controllers", true, "Whether federation controllers should be started in memory.  Ignored if test-managed-cluster is false")
-	flag.StringVar(&t.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"), "Path to kubeconfig containing embedded authinfo.  Ignored if test-managed-cluster is true")
-	flag.StringVar(&t.KubeContext, "context", "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
+	flag.BoolVar(&t.TestManagedFederation, "test-managed-federation",
+		false, "Whether the test run should rely on a test-managed federation.")
+	flag.BoolVar(&t.InMemoryControllers, "in-memory-controllers", false,
+		"Whether federation controllers should be started in memory. This works like a hybrid setup if test-managed-federation is false by launching the federation controllers outside the unmanaged cluster.")
+	flag.StringVar(&t.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"),
+		"Path to kubeconfig containing embedded authinfo.  Ignored if test-managed-federation is true.")
+	flag.StringVar(&t.KubeContext, "context", "",
+		"kubeconfig context to use/override. If unset, will use value from 'current-context'.")
 }
 
 func validateFlags(t *TestContextType) {
@@ -48,8 +52,7 @@ func validateFlags(t *TestContextType) {
 	}
 
 	if !t.TestManagedFederation && t.InMemoryControllers {
-		glog.Info("in-memory-controllers require test-managed-federation=true - disabling.")
-		t.InMemoryControllers = false
+		glog.Info("in-memory-controllers=true while test-managed-federation=false - this will launch the federation controllers outside the unmanaged cluster.")
 	}
 }
 

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -4,7 +4,6 @@ Copyright 2018 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
@@ -26,6 +25,9 @@ import (
 	fedclientset "github.com/marun/federation-v2/pkg/client/clientset_generated/clientset"
 	"github.com/marun/federation-v2/pkg/controller/util"
 	"github.com/marun/federation-v2/pkg/federatedtypes"
+	"github.com/marun/federation-v2/pkg/kubefnord"
+	"github.com/marun/federation-v2/test/common"
+	"github.com/marun/federation-v2/test/integration/framework"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +35,7 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	crclientset "k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
 
 	. "github.com/onsi/ginkgo"
@@ -40,7 +43,41 @@ import (
 )
 
 // Only check that the api is available once
-var checkedApi bool
+var (
+	clusterControllerFixture *framework.ControllerFixture
+	checkedApi               bool
+)
+
+func SetUpUnManagedFederation() {
+	if clusterControllerFixture != nil {
+		return
+	}
+
+	if TestContext.KubeConfig == "" {
+		Failf("--kubeconfig or KUBECONFIG must be specified to load client config")
+	}
+
+	config, kubeConfig, err := loadConfig(TestContext.KubeConfig, TestContext.KubeContext)
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterControllerFixture = framework.NewClusterControllerFixture(config, config, config)
+
+	// TODO(font): Support joining multiple clusters.
+	hostClusterName := kubeConfig.CurrentContext
+	err = kubefnord.JoinCluster(config, config, config,
+		util.FederationSystemNamespace, hostClusterName, hostClusterName, "", true, false)
+	if err != nil {
+		Failf("Failed to join cluster %s: %v", hostClusterName, err)
+	}
+}
+
+func TearDownUnManagedFederation() {
+	if clusterControllerFixture != nil {
+		clusterControllerFixture.TearDown(NewE2ELogger())
+		clusterControllerFixture = nil
+	}
+	// TODO(font): Unjoin clusters.
+}
 
 type UnmanagedFramework struct {
 	// To make sure that this framework cleans up after itself, no matter what,
@@ -53,11 +90,18 @@ type UnmanagedFramework struct {
 	Config *restclient.Config
 
 	BaseName string
+
+	logger common.TestLogger
+
+	// Fixtures to cleanup after each test
+	fixtures []framework.TestFixture
 }
 
 func NewUnmanagedFramework(baseName string) FederationFramework {
 	f := &UnmanagedFramework{
 		BaseName: baseName,
+		logger:   NewE2ELogger(),
+		fixtures: []framework.TestFixture{},
 	}
 	return f
 }
@@ -74,7 +118,7 @@ func (f *UnmanagedFramework) BeforeEach() {
 			Failf("--kubeconfig or KUBECONFIG must be specified to load client config")
 		}
 		var err error
-		f.Config, err = loadConfig(TestContext.KubeConfig, TestContext.KubeContext)
+		f.Config, _, err = loadConfig(TestContext.KubeConfig, TestContext.KubeContext)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
@@ -110,7 +154,13 @@ func (f *UnmanagedFramework) AfterEach() {
 		deleteNamespace(client, namespaceName)
 	}()
 
-	// Print events if the test failed and ran in a namep.
+	for len(f.fixtures) > 0 {
+		fixture := f.fixtures[0]
+		fixture.TearDown(f.logger)
+		f.fixtures = append(f.fixtures[:0], f.fixtures[1:]...)
+	}
+
+	// Print events if the test failed and ran in a namespace.
 	if CurrentGinkgoTestDescription().Failed && f.testNamespaceName != "" {
 		kubeClient := f.KubeClient(userAgent)
 		DumpEventsInNamespace(func(opts metav1.ListOptions, ns string) (*corev1.EventList, error) {
@@ -176,7 +226,14 @@ func (f *UnmanagedFramework) TestNamespaceName() string {
 }
 
 func (f *UnmanagedFramework) SetUpControllerFixture(kind string, adapterFactory federatedtypes.AdapterFactory) {
-	// Not supported
+	// Hybrid setup where just the sync controller is run and we do not rely on
+	// the already deployed (unmanaged) controller manager. Only do this if
+	// in-memory-controllers is true.
+	if TestContext.InMemoryControllers {
+		fixture := framework.NewSyncControllerFixture(f.logger, kind, adapterFactory, f.Config,
+			f.Config, f.Config)
+		f.fixtures = append(f.fixtures, fixture)
+	}
 }
 
 func createNamespace(client kubeclientset.Interface, baseName string) (string, error) {
@@ -234,11 +291,11 @@ func deleteNamespace(client kubeclientset.Interface, namespaceName string) {
 	}
 }
 
-func loadConfig(configPath, context string) (*restclient.Config, error) {
+func loadConfig(configPath, context string) (*restclient.Config, *clientcmdapi.Config, error) {
 	Logf(">>> kubeConfig: %s", configPath)
 	c, err := clientcmd.LoadFromFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("error loading kubeConfig %s: %v", configPath, err.Error())
+		return nil, nil, fmt.Errorf("error loading kubeConfig %s: %v", configPath, err.Error())
 	}
 	if context != "" {
 		Logf(">>> kubeContext: %s", context)
@@ -246,9 +303,9 @@ func loadConfig(configPath, context string) (*restclient.Config, error) {
 	}
 	cfg, err := clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error creating default client config: %v", err.Error())
+		return nil, nil, fmt.Errorf("error creating default client config: %v", err.Error())
 	}
-	return cfg, nil
+	return cfg, c, nil
 }
 
 // waitForApiserver waits for the apiserver to be ready.  It tests the
@@ -306,14 +363,15 @@ func ClusterIsReadyOrFail(client fedclientset.Interface, cluster fedv1a1.Federat
 	clusterName := cluster.Name
 	By(fmt.Sprintf("Checking readiness of cluster %q", clusterName))
 	err := wait.PollImmediate(PollInterval, SingleCallTimeout, func() (bool, error) {
+		cluster, err := client.FederationV1alpha1().FederatedClusters().Get(clusterName,
+			metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
 		for _, condition := range cluster.Status.Conditions {
 			if condition.Type == fedcommon.ClusterReady && condition.Status == corev1.ConditionTrue {
 				return true, nil
 			}
-		}
-		_, err := client.FederationV1alpha1().FederatedClusters().Get(clusterName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
 		}
 		return false, nil
 	})

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -32,7 +32,7 @@ const (
 	// transient failures from failing tests.
 	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
 	PollInterval      = 2 * time.Second
-	SingleCallTimeout = 5 * time.Minute
+	SingleCallTimeout = 30 * time.Second
 )
 
 // unique identifier of the e2e run

--- a/test/integration/crud_test.go
+++ b/test/integration/crud_test.go
@@ -60,7 +60,7 @@ func initCrudTest(tl common.TestLogger, fedFixture *framework.FederationFixture,
 	fedConfig := fedFixture.FedApi.NewConfig(tl)
 	kubeConfig := fedFixture.KubeApi.NewConfig(tl)
 	crConfig := fedFixture.CrApi.NewConfig(tl)
-	fixture := framework.NewControllerFixture(tl, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
+	fixture := framework.NewSyncControllerFixture(tl, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
 
 	userAgent := fmt.Sprintf("crud-test-%s", kind)
 

--- a/test/integration/framework/controller.go
+++ b/test/integration/framework/controller.go
@@ -17,6 +17,9 @@ limitations under the License.
 package framework
 
 import (
+	"time"
+
+	"github.com/marun/federation-v2/pkg/controller/federatedcluster"
 	"github.com/marun/federation-v2/pkg/controller/sync"
 	"github.com/marun/federation-v2/pkg/federatedtypes"
 	"github.com/marun/federation-v2/test/common"
@@ -28,8 +31,8 @@ type ControllerFixture struct {
 	stopChan chan struct{}
 }
 
-// NewControllerFixture initializes a new controller fixture
-func NewControllerFixture(tl common.TestLogger, kind string, adapterFactory federatedtypes.AdapterFactory, fedConfig, kubeConfig, crConfig *restclient.Config) *ControllerFixture {
+// NewSyncControllerFixture initializes a new sync controller fixture.
+func NewSyncControllerFixture(tl common.TestLogger, kind string, adapterFactory federatedtypes.AdapterFactory, fedConfig, kubeConfig, crConfig *restclient.Config) *ControllerFixture {
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
@@ -37,6 +40,17 @@ func NewControllerFixture(tl common.TestLogger, kind string, adapterFactory fede
 	if err != nil {
 		tl.Fatalf("Error starting sync controller: %v", err)
 	}
+	return f
+}
+
+// NewClusterControllerFixture initializes a new cluster controller fixture.
+func NewClusterControllerFixture(fedConfig, kubeConfig, crConfig *restclient.Config) *ControllerFixture {
+	f := &ControllerFixture{
+		stopChan: make(chan struct{}),
+	}
+	monitorPeriod := 1 * time.Second
+	federatedcluster.StartClusterController(fedConfig, kubeConfig, crConfig,
+		f.stopChan, monitorPeriod)
 	return f
 }
 

--- a/test/integration/framework/federation.go
+++ b/test/integration/framework/federation.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	fedv1a1 "github.com/marun/federation-v2/pkg/apis/federation/v1alpha1"
-	"github.com/marun/federation-v2/pkg/controller/federatedcluster"
 	"github.com/marun/federation-v2/pkg/controller/util"
 	"github.com/marun/federation-v2/test/common"
 	apiv1 "k8s.io/api/core/v1"
@@ -41,13 +40,11 @@ const userAgent = "federation-framework"
 // FederationFixture manages servers for kube, cluster registry and
 // federation along with a set of member clusters.
 type FederationFixture struct {
-	stopChan chan struct{}
-
-	KubeApi *KubernetesApiFixture
-	CrApi   *ClusterRegistryApiFixture
-	FedApi  *FederationApiFixture
-
-	Clusters map[string]*KubernetesApiFixture
+	KubeApi           *KubernetesApiFixture
+	CrApi             *ClusterRegistryApiFixture
+	FedApi            *FederationApiFixture
+	Clusters          map[string]*KubernetesApiFixture
+	ClusterController *ControllerFixture
 }
 
 func SetUpFederationFixture(tl common.TestLogger, clusterCount int) *FederationFixture {
@@ -74,25 +71,20 @@ func (f *FederationFixture) setUp(tl common.TestLogger, clusterCount int) {
 
 	// TODO(marun) Consider running the cluster controller as soon as
 	// the kube api is available to speed up setting cluster status.
-	f.stopChan = make(chan struct{})
-	monitorPeriod := 1 * time.Second
 	tl.Logf("Starting cluster controller")
-	federatedcluster.StartClusterController(f.FedApi.NewConfig(tl), f.KubeApi.NewConfig(tl), f.CrApi.NewConfig(tl), f.stopChan, monitorPeriod)
-
+	f.ClusterController = NewClusterControllerFixture(f.FedApi.NewConfig(tl),
+		f.KubeApi.NewConfig(tl), f.CrApi.NewConfig(tl))
 	tl.Log("Federation started.")
 }
 
 func (f *FederationFixture) TearDown(tl common.TestLogger) {
 	// Stop the cluster controller first to avoid spurious connection
 	// errors when the target urls become unavailable.
-	if f.stopChan != nil {
-		close(f.stopChan)
-		f.stopChan = nil
-	}
 	fixtures := []TestFixture{
-		// KubeApi will be torn down via f.Clusters
+		f.ClusterController,
 		f.CrApi,
 		f.FedApi,
+		// KubeApi will be torn down via f.Clusters
 	}
 	for _, cluster := range f.Clusters {
 		fixtures = append(fixtures, cluster)


### PR DESCRIPTION
**NOTE: This should ideally be merged immediately after #48 but before #49.**

This adds support for running E2E tests with in-memory-controllers in an unmanaged federation (hybrid).